### PR TITLE
[update] Update peer deps to support React 16

### DIFF
--- a/example/index.jsx
+++ b/example/index.jsx
@@ -1,6 +1,9 @@
-import React, { Component, Children, PropTypes } from 'react'
+import React, { Component, Children } from 'react'
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom'
-import { AriaManager, AriaToggle, AriaPopover } from 'react-aria'
+// TODO: Uncomment once react-aria has been updated to support React 16
+// import { AriaManager, AriaToggle, AriaPopover } from 'react-aria'
+
 import Travel from '../src/react-travel'
 
 import './main.scss'
@@ -11,31 +14,34 @@ class Popover extends Component {
   }
 
   render() {
+    return null;
     const { isOpen } = this.state
-    return (
-      <AriaManager
-        type="popover"
-        onPopoverOpen={() => this.setState({ isOpen: true })}
-        onPopoverClose={() => this.setState({ isOpen: false })}
-        openPopoverOn="hover"
-      >
-        <div>
-          <h3>Popover</h3>
-          <AriaToggle className="popover-toggle">
-            Toggle Popover <span>👻</span>
-          </AriaToggle>
-          {isOpen &&
-            <Travel>
-              <AriaPopover>
-                Some cool popover content.
-              </AriaPopover>
-            </Travel>}
-          <div>
-            Popover is {isOpen ? 'Open' : 'Closed'}
-          </div>
-        </div>
-      </AriaManager>
-    )
+    return null;
+    // TODO: Uncomment once react-aria has been updated to support React 16
+    // return (
+    //   <AriaManager
+    //     type="popover"
+    //     onPopoverOpen={() => this.setState({ isOpen: true })}
+    //     onPopoverClose={() => this.setState({ isOpen: false })}
+    //     openPopoverOn="hover"
+    //   >
+    //     <div>
+    //       <h3>Popover</h3>
+    //       <AriaToggle className="popover-toggle">
+    //         Toggle Popover <span>👻</span>
+    //       </AriaToggle>
+    //       {isOpen &&
+    //         <Travel>
+    //           <AriaPopover>
+    //             Some cool popover content.
+    //           </AriaPopover>
+    //         </Travel>}
+    //       <div>
+    //         Popover is {isOpen ? 'Open' : 'Closed'}
+    //       </div>
+    //     </div>
+    //   </AriaManager>
+    // )
   }
 }
 class Dropdown extends Component {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "homepage": "https://github.com/souporserious/react-travel",
   "peerDependencies": {
-    "react": "0.14.x || ^15.0.0",
-    "react-dom": "0.14.x || ^15.0.0"
+    "react": "0.14.x || ^15.0.0 || ^16.0.0",
+    "react-dom": "0.14.x || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",
@@ -53,15 +53,15 @@
     "node-libs-browser": "^1.0.0",
     "node-sass": "^3.2.0",
     "postcss-loader": "^0.13.0",
-    "react": "15.3.2",
+    "react": "16.2.0",
     "react-aria": "^0.4.0",
-    "react-dom": "15.3.2",
+    "react-dom": "16.2.0",
     "sass-loader": "^4.0.2",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.9.0"
   },
   "dependencies": {
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.6.0"
   }
 }


### PR DESCRIPTION
Will allow usage with React 16 without warnings. 

Tested the example locally and it still works as intended. Note that I commented out usage of `react-aria` as it is breaking in the example because of the props check that happens: https://github.com/souporserious/react-aria/blob/master/src/Items/ItemList.jsx#L69